### PR TITLE
Allow escaped single quotes

### DIFF
--- a/jslistings.sty
+++ b/jslistings.sty
@@ -41,7 +41,7 @@
     sensitive=true,
     stringstyle=\color{string}\ttfamily,
     morestring=[b]",
-    morestring=[d]',
+    morestring=[b]',
     morestring=[s][\color{string}\ttfamily]{`}{`},
     commentstyle=\color{red}\itshape,
     morecomment=[l][\color{allcomment}]{//},


### PR DESCRIPTION
I'm not completely sure what the side effects are of this, as I can't find any documentation on the matter, but it does solve the problem.

## Issue fixed

#4

## Proposed Changes

  - Change single-quote `morestring` option from `[d]` to `[b]`, just like the double-quote equivalent.

@xgirma
