### PR TITLE
RegExp literal support

### DIFF
--- a/jslistings.sty
+++ b/jslistings.sty
@@ -43,6 +43,7 @@
     morestring=[b]",
     morestring=[d]',
     morestring=[s][\color{string}\ttfamily]{`}{`},
+    morestring=[b][\color{orange}]/, % regex literal, so technically not a string
     commentstyle=\color{red}\itshape,
     morecomment=[l][\color{allcomment}]{//},
     morecomment=[s][\color{allcomment}]{/*}{*/},


### PR DESCRIPTION
## Issue Fixed

Close #6

## Proposed Changes

  - Add basic RegExp literal support (by adding a string type). The string type is necessary (AFAIK), to allow escaped forward slashes (`\/`) in literals

@xgirma
